### PR TITLE
ReAdd original default_group_full for task so that both project with …

### DIFF
--- a/project_scrum/project_scrum.py
+++ b/project_scrum/project_scrum.py
@@ -231,13 +231,54 @@ class project_task(models.Model):
         #self._group_by_full['us_id'] = _read_group_us_id
         #super(project_task, self)._auto_init(cr, context)
 
+    def _read_group_stage_ids(self, cr, uid, ids, domain, read_group_order=None, access_rights_uid=None, context=None):
+        stage_obj = self.pool.get('project.task.type')
+        order = stage_obj._order
+        access_rights_uid = access_rights_uid or uid
+        if read_group_order == 'stage_id desc':
+            order = '%s desc' % order
+        search_domain = []
+        project_id = self._resolve_project_id_from_context(cr, uid, context=context)
+        if project_id:
+            search_domain += ['|', ('project_ids', '=', project_id)]
+        search_domain += [('id', 'in', ids)]
+        stage_ids = stage_obj._search(cr, uid, search_domain, order=order, access_rights_uid=access_rights_uid, context=context)
+        result = stage_obj.name_get(cr, access_rights_uid, stage_ids, context=context)
+        # restore order of the search
+        result.sort(lambda x,y: cmp(stage_ids.index(x[0]), stage_ids.index(y[0])))
+
+        fold = {}
+        for stage in stage_obj.browse(cr, access_rights_uid, stage_ids, context=context):
+            fold[stage.id] = stage.fold or False
+        return result, fold
+
+    def _read_group_user_id(self, cr, uid, ids, domain, read_group_order=None, access_rights_uid=None, context=None):
+        res_users = self.pool.get('res.users')
+        project_id = self._resolve_project_id_from_context(cr, uid, context=context)
+        access_rights_uid = access_rights_uid or uid
+        if project_id:
+            ids += self.pool.get('project.project').read(cr, access_rights_uid, project_id, ['members'], context=context)['members']
+            order = res_users._order
+            # lame way to allow reverting search, should just work in the trivial case
+            if read_group_order == 'user_id desc':
+                order = '%s desc' % order
+            # de-duplicate and apply search order
+            ids = res_users._search(cr, uid, [('id','in',ids)], order=order, access_rights_uid=access_rights_uid, context=context)
+        result = res_users.name_get(cr, access_rights_uid, ids, context=context)
+        # restore order of the search
+        result.sort(lambda x,y: cmp(ids.index(x[0]), ids.index(y[0])))
+        return result, {}
+    
     try:
         _group_by_full['sprint_id'] = _read_group_sprint_id
         _group_by_full['us_id'] = _read_group_us_id
     except:
         _group_by_full = {
-        'sprint_id': _read_group_sprint_id,
-        'us_id': _read_group_us_id,
+            'sprint_id': _read_group_sprint_id,
+            'us_id': _read_group_us_id,
+            'stage_id': _read_group_stage_ids,
+            'user_id': _read_group_user_id,
+            
         }
 
 class project_actors(models.Model):


### PR DESCRIPTION
Hy,

Your module consider that all the projects has to be managed through Scrum and via sprints etc..
This causes the Kanban Column to disappears if empty when the project is not a Scrum One.
I re add the original _group_by_full in your code so that it still work as before.
