### PR TITLE
[FIX] project_scrum. Removed duplicate field in view

### DIFF
--- a/project_scrum/__openerp__.py
+++ b/project_scrum/__openerp__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Project Scrum',
-    'version': '1.6',
+    'version': '1.6.1',
     'category': 'Project Management',
     'description': """
 Using Scrum to plan the work in a team.

--- a/project_scrum/project_scrum_view.xml
+++ b/project_scrum/project_scrum_view.xml
@@ -740,12 +740,18 @@
                     <label for="use_scrum" string="Use Scrum"/>
                 </field>
                 <field name="user_id" position="replace">
-                    <field name="user_id" string="Scrum Master" attrs="{'invisible': [('use_scrum', '=', False)]}"/>
-                    <field name="user_id" string="Project Manager" attrs="{'invisible': [('use_scrum', '=', True)]}"/>
+                    <label for="user_id" attrs="{'invisible': [('use_scrum', '=', True)]}"/>
+                    <label for="user_id" string="Scrum Master" attrs="{'invisible': [('use_scrum', '=', False)]}"/>
+                    <div>
+                        <field name="user_id"/>
+                    </div>
                 </field>
                 <field name="partner_id" position="replace">
-                    <field name="partner_id" string="Product Owner" attrs="{'invisible': [('use_scrum', '=', False)]}"/>
-                    <field name="partner_id" string="Customer" attrs="{'invisible': [('use_scrum', '=', True)]}"/>
+                    <label for="partner_id" attrs="{'invisible': [('use_scrum', '=', True)]}"/>
+                    <label for="partner_id" string="Product Owner" attrs="{'invisible': [('use_scrum', '=', False)]}"/>
+                    <div>
+                        <field name="partner_id"/>
+                    </div>                    
                 </field>
                 <page name="project_stages" position="after">
                     <page name="tasks" string="Tasks">


### PR DESCRIPTION
Same field can only be used/defined once per view. Using it more
than once, causes view to be bugged. To show different label for
same field, multiple label tags can be used alternatively.
