### PR TITLE
Removed duplicate field in User Story view

### DIFF
--- a/project_scrum/project_scrum_view.xml
+++ b/project_scrum/project_scrum_view.xml
@@ -258,7 +258,6 @@
             <field name="type">form</field>
             <field name="arch" type="xml">
                 <form string="User Stories">
-                    <field name="project_id" invisible="1"/>
                     <sheet string="User Story">
                     <h1>
                         <field name="name" placeholder="User Story..." class="oe_inline"/>


### PR DESCRIPTION
That line was causing errors while inheriting from project.scrum.us view.
Since the project_id field is already defined in that view, I think it's safe to remove the hidden one.