### PR TITLE
Project.task already has a description field and it is text 

### DIFF
--- a/project_scrum/project_scrum.py
+++ b/project_scrum/project_scrum.py
@@ -215,7 +215,6 @@ class project_task(models.Model):
     date_start = fields.Datetime(string = 'Starting Date', required=False, default=fields.Datetime.now())
     date_end = fields.Datetime(string = 'Ending Date', required=False)
     use_scrum = fields.Boolean(related='project_id.use_scrum')
-    description = fields.Html('Description')
     current_sprint = fields.Boolean(compute='_current_sprint', string='Current Sprint', search='_search_current_sprint')
 
     @api.depends('sprint_id')


### PR DESCRIPTION
We remove  definition of description Project.py in project task model already has a description field and it is text. For consistency with the project.issue model we leave it at text.
In particular we found some problems when using this module with a sync tasks-issues  module I wrote , the HTML vs TEXT description of issues and tasks gave some.
Overwritten field in project.py by this module:
https://github.com/OCA/OCB/blob/8.0/addons/project/project.py#L734

For your consideration to merge this.


